### PR TITLE
fix missing cache-manager-redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: required
 dist: trusty
 node_js: '4.1'
 script:
-  - npm run serve & npm test
+  - npm run dev & npm test
   - npm run lint
   - npm run lint:checkstyle
-  - npm run swagger:validate
+  - sleep 10; npm run swagger:validate
 notifications:
   slack:
       secure: x5VInJNsQnnyYiZ6PDCh4A1FHw/PuFT3VwbH0XBrFDIcEbgbibkUk4I/BKwHb57onwcNQwNkzfnsgB50eu93U6o8iqQ8yCHN1+bfYIBdkuVDG2kVD69Qfs9zMkT0tw0S/OPF1+p/X25+AOwes5aeQoUvfsQGvwBYroY/YHsDa91bCxO88lT+7RgNoVM2eDQkqPfwuhrHuPKtXUHYNc71XIvmyjCVG4ANVyMVxYWGna8aLqLUQHRDThwytUKxe+SEo14paPgbwuy8CMsMnVSROxMaDawkp/SqXSrx5tjd54D8DUtLLuD/sSOaTiWvJ8ZE7yLoAKCVmHdRfeW+S2wDR3K6271Ne0GD2XCcDBC+UKm+j7AWvMJbYg7eD0xfnCb5RQTRvNVnQnR/nypn01/nAhkmv2Fl3a7Rn7rvHzEnpTf2+cSM1+uFgy7wuocQwn3gociwNrAqjm4V+gsI8bSwhvTjfXBRWiutrbPDSw6R3uGctYclbvL+j8+tcCRlE5WhEyfq9h2Jzjwju7qsBjsAOWfVF5NyqEFkCxFspHZIWuqIBpA0XFUtx0TuREgVAizkZCX+3hnhBtxlCg2gXHTObnrPEplHj44zkYV6mKHZhNN6wM01tdy9q17PV5zAHe0SThYKdlPGmF/3mYjjQN2BK01Z34sjax+0pS8uEAP+WFg=

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "siege": "siege -c500 -d10 -t30M -i -f siegetestendpoints.txt",
     "siege:live": "siege -c50 -d10 -t10M -i -f siegedemoendpoints.txt",
     "start": "node src/main.js",
-    "swagger:validate": "curl localhost:8080/api/swagger.json | swagger validate",
+    "swagger:validate": "curl localhost:8080/v0/swagger.json | swagger validate",
     "test": "mocha --compilers js:babel/register --recursive src/**/__tests__/*",
     "test:single": "mocha --compilers js:babel/register",
     "tail": "tail -f log.log",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "body-parser": "1.14.1",
     "compression": "1.6.0",
     "cache-manager": "^1.0.0",
+    "cache-manager-redis": "0.2.1",
     "connect-redis": "3.0.0",
     "css-loader": "0.22.0",
     "dbc-node-basesoap-client": "^1.1.1",

--- a/src/app.js
+++ b/src/app.js
@@ -42,6 +42,7 @@ module.exports.run = function (worker) {
         fs.readFileSync(
           process.env.CONFIG_FILE || // eslint-disable-line no-process-env
             __dirname + '/../config.json', 'utf8'));
+  config.cache.store = require('cache-manager-redis');
 
   // Direct requests to app
   server.on('request', app);

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -64,10 +64,10 @@ export default function Provider(logger) {
   }
 
   // we are going to reimplement a simpler mechanism to call the transformers
-  function execute(name, params, context){
+  function execute(name, params, context) { // eslint-disable-line no-unused-vars
     return {};
   }
-    
+
   function availableTransforms() {
     return transforms.keys();
   }
@@ -76,6 +76,7 @@ export default function Provider(logger) {
     registerTransform,
     registerServiceClient,
     availableTransforms,
+    execute,
     trigger
   };
 }

--- a/src/swaggerFromSpec.js
+++ b/src/swaggerFromSpec.js
@@ -49,7 +49,7 @@ function specToPaths(specs) {
           }
         }
       };
-      paths[method] = {post: obj};
+      paths['/' + method] = {post: obj};
     }
   }
   return paths;


### PR DESCRIPTION
Turns out that dbc-config included a cache manager in  addition to the configuration, which is why the serviceprovider temporarily didn't work.

- + linting fixes
- + swagger validate