### PR TITLE
hide X-Powered-By header entirely

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -51,10 +51,12 @@ module.exports.run = function (worker) {
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({extended: true}));
 
+  // don't set the X-Powered-By header
+  app.disable('x-powered-by');
+
   // Helmet configuration
   // TODO: Setup rest of Helmet, in a way that works with the server setup.
   app.use(helmet.frameguard());
-  app.use(helmet.hidePoweredBy({setTo: 'Funkys Venner!'}));
   app.use(helmet.ieNoOpen());
   app.use(helmet.noSniff());
 


### PR DESCRIPTION
It's silly that Express is so proud of itself in the first place, but replacing "X-Powered-By: Express" with "X-Powered-By: Funkys Venner!" is also silly. Let's just get rid of it entirely, and save the bandwidth. ;-)

/adam
Removing fun stuff since 1987