### PR TITLE
remove invalid third argument to ServiceProviderSetup

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -62,7 +62,7 @@ module.exports.run = function (worker) {
   app.set('port', process.env.PORT || 8080); // eslint-disable-line no-process-env
 
   // Configure app variables
-  let serviceProvider = ServiceProviderSetup(config, logger, worker);
+  let serviceProvider = ServiceProviderSetup(config, logger);
   app.set('serviceProvider', serviceProvider);
   app.set('logger', logger);
 


### PR DESCRIPTION
ServiceProviderSetup is called with an extra argument, which have now been removed.