### PR TITLE
make utils.js utilize import/export instead of require

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,14 +1,11 @@
 'use strict';
-/**
- * @file
- * Common functions for service provider
- */
-const fs = require('fs');
+
+import fs from 'fs';
 
 /**
 * Die function. Writes to console and throws error
 */
-function die(str) {
+export function die(str) {
   console.trace('ERROR: ' + str); // eslint-disable-line
   throw (str);
 }
@@ -16,7 +13,7 @@ function die(str) {
 /**
 * Returns the name of the given function
 */
-function functionName(fun) {
+export function functionName(fun) {
   let ret = fun.toString();
   ret = ret.substr('function '.length);
   ret = ret.substr(0, ret.indexOf('('));
@@ -27,7 +24,7 @@ function functionName(fun) {
  * Logs object to console as JSON.
  * The function adds a timestamp to the json object (key=logTimestamp)
  */
-function logJSON(object) {
+export function logJSON(object) {
   object.logTimestamp = Math.floor(new Date() / 1000);
   console.log(JSON.stringify(object)); // eslint-disable-line
 }
@@ -36,7 +33,7 @@ function logJSON(object) {
 * return true if the given path is an existing directory, false
 * otherwise.
 */
-function isDir(path) {
+export function isDir(path) {
   try {
     let stats = fs.lstatSync(path);
     if (stats.isDirectory()) {
@@ -46,8 +43,3 @@ function isDir(path) {
     catch (e) {} // eslint-disable-line
   return false;
 }
-
-module.exports.die = die;
-module.exports.functionName = functionName;
-module.exports.logJSON = logJSON;
-module.exports.isDir = isDir;


### PR DESCRIPTION
We should only use `require` and friends when babel haven't been loaded yet.