### PR TITLE
Allow http in swagger spec (needed when running on localhost etc.)

### DIFF
--- a/src/swaggerFromSpec.js
+++ b/src/swaggerFromSpec.js
@@ -125,8 +125,8 @@ export default function(specName = 'spec') {
           title: 'DBC ServiceProvider',
           description: desc
         },
-        basePath: '/v' + majorVersion + '/',
-        schemes: ['https', 'wss'],
+        basePath: '/v' + majorVersion,
+        schemes: ['http', 'https', 'wss'],
         consumes: ['application/json'],
         produces: ['application/json'],
         paths: specToPaths(spec),


### PR DESCRIPTION
Fix relative api-url, and allow http in the swagger spec, - this fixes #152. When deployed, it should
 only use https, but adding http as a scheme in the swagger.json, allows swagger-ui to be used on development as well as production setup.

After this, it should be possible to run test-requests via the swagger-documentation.