### PR TITLE
Functional getObjectTransformer.

### DIFF
--- a/src/provider/neoCoverImageTransform.js
+++ b/src/provider/neoCoverImageTransform.js
@@ -157,7 +157,7 @@ function getImageSizeAndUrl(x) {
   let res = {};
   if (_.has(x, 'attributes.imageSize') && _.has(x, '$value')) {
     let is = IMAGE_SIZES[x.attributes.imageSize];
-    res[is] = x.$value.replace('http:', '');
+    res[is] = [x.$value.replace('http:', '')];
   }
   return res;
 }

--- a/src/provider/neoOpenSearchWorkTransformer.js
+++ b/src/provider/neoOpenSearchWorkTransformer.js
@@ -62,13 +62,8 @@ function retrieveDkabmFields(lookup, result) {
     });
 
     a.map(X => {
-      //let k = X.ns + ':' + key;
-      //if (X.type) {
-      //  k += '/' + X.type;
-      //}
       let identifier = X.ns + ':' + key;
       let field = X.type ? typeId.getField(identifier, X.type) : typeId.getField(identifier);
-      // console.log("Field: " + field);
       if (result[field]) {
         result[field].push(X.value);
       } else { // eslint-disable-line brace-style
@@ -95,7 +90,7 @@ function getBriefDisplayData(response) {
   let briefDisplay = searchResult[0].formattedCollection.briefDisplay.manifestation[0];
 
   let res = {};
-  _.forOwn(briefDisplay, (value,key) => {
+  _.forOwn(briefDisplay, (value, key) => {
     let ns = 'bd';
     let identifier = ns + ':' + key;
     let field = typeId.getField(identifier);
@@ -111,7 +106,7 @@ function getRelationData(response) {
   let res = {};
   _.forEach(relations, relation => {
     let field = typeId.getField(relation.relationType.$);
-    if(!res[field]) {
+    if (!res[field]) {
       res[field] = [];
     }
     res[field].push(relation.relationUri.$);

--- a/src/requestTypeIdentifier.js
+++ b/src/requestTypeIdentifier.js
@@ -15,7 +15,7 @@
 *
 */
 import fs from 'fs';
-import {findKey} from 'lodash';
+import {isEqual} from 'lodash';
 import {die} from './utils.js';
 
 
@@ -65,6 +65,8 @@ export function TypeID(workContext) {
     dbcaddi: requestType.RELATIONS,
     dbcbib: requestType.RELATIONS
   };
+
+  //console.log("WC: " + JSON.stringify(this.workContext, null, 4));
 
   /**
    * Gets type of field
@@ -122,7 +124,16 @@ export function TypeID(workContext) {
     if (typeof type !== 'undefined') {
       obj['@type'] = type;
     }
-    return findKey(workContext, obj);
+    let res;
+    for(let key in this.workContext) {
+      if(!this.workContext.hasOwnProperty(key)) {
+        continue;
+      }
+      if(isEqual(workContext[key], obj)) {
+        res = key;
+      }
+    }
+    return res;
   };
 }
 

--- a/src/requestTypeIdentifier.js
+++ b/src/requestTypeIdentifier.js
@@ -66,8 +66,6 @@ export function TypeID(workContext) {
     dbcbib: requestType.RELATIONS
   };
 
-  //console.log("WC: " + JSON.stringify(this.workContext, null, 4));
-
   /**
    * Gets type of field
    * @param {string} field returns endpoint type for field
@@ -119,17 +117,17 @@ export function TypeID(workContext) {
    *
    * @api public
    */
-  this.getField = function(id, type) {
+  this.getField = function (id, type) {
     let obj = {'@id': id};
     if (typeof type !== 'undefined') {
       obj['@type'] = type;
     }
     let res;
-    for(let key in this.workContext) {
-      if(!this.workContext.hasOwnProperty(key)) {
+    for (let key in this.workContext) {
+      if (!this.workContext.hasOwnProperty(key)) {
         continue;
       }
-      if(isEqual(workContext[key], obj)) {
+      if (isEqual(workContext[key], obj)) {
         res = key;
       }
     }


### PR DESCRIPTION
The transformer now seems to be correct for handling the getObject-method in OpenSearch, that is - dkabm, briefDisplay and relations.

coverUrls have also been fixed - now they return their urls in lists.

A bug has also been fixed in requestTypeIdentifier.js: The getField-function used lodashs findKey, which did not return the correct result. If searching for {"@id": "x"}, and the workContext contained both {"@id":"x", "@type":"y"} and {"@id":"x"} in that order, the first was returned, since a subset-match is ok for findKey. This has been changed into an unelegant for-loop. Please find a prettier solution.