### PR TITLE
work endpoint now uses context.call

### DIFF
--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -32,7 +32,7 @@ export default function Provider() {
     facets: facetTransformer,
     recommend: recommendTransformer(),
     suggest: suggestTransformer,
-    getCoverImageNeo: coverImageTransformer(),
+    getCoverImageNeo: coverImageTransformer,
     getOpenSearchWorkNeo: openSearchWorkTransformer(),
     work: workTransformer()
   };

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -33,7 +33,7 @@ export default function Provider() {
     recommend: recommendTransformer(),
     suggest: suggestTransformer,
     getCoverImageNeo: coverImageTransformer,
-    getOpenSearchWorkNeo: openSearchWorkTransformer(),
+    getOpenSearchWorkNeo: openSearchWorkTransformer,
     work: workTransformer()
   };
 

--- a/src/provider/Provider.js
+++ b/src/provider/Provider.js
@@ -34,7 +34,7 @@ export default function Provider() {
     suggest: suggestTransformer,
     getCoverImageNeo: coverImageTransformer,
     getOpenSearchWorkNeo: openSearchWorkTransformer,
-    work: workTransformer()
+    work: workTransformer
   };
 
   // we are going to reimplement a simpler mechanism to call the transformers

--- a/src/provider/neoOpenSearchWorkTransformer.js
+++ b/src/provider/neoOpenSearchWorkTransformer.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import genericTransformer from '../genericTransformer';
-import {sendRequest} from '../services/HTTPClient';
 import {requestType, makeTypeID} from '../requestTypeIdentifier';
 import _ from 'lodash';
 
@@ -225,16 +223,10 @@ export function responseTransform(response, context, state) { // eslint-disable-
   return {statusCode: 200, data: data};
 }
 
-export function opensearchGetObjectFunc(context) {
-  if (!_.has(context, 'opensearch.url')) {
-    throw new Error('no opensearch url provided in context.');
-  }
+export default (request, context) => {
+  let {transformedRequest: params, state: state} = requestTransform(request, context);
 
-  return function (request, local_context, state) { // eslint-disable-line no-unused-vars
-    return {response: sendRequest(context.opensearch.url, request), state: state};
-  };
-}
-
-export default function getObjectTransformer() {
-  return genericTransformer(requestTransform, responseTransform, opensearchGetObjectFunc);
-}
+  return context.call('opensearch', params).then(body => {
+    return responseTransform(body, context, state);
+  });
+};

--- a/src/provider/neoWorkTransformer.js
+++ b/src/provider/neoWorkTransformer.js
@@ -159,7 +159,7 @@ export function workFunc(context) {
     }
     if (_.has(request, requestMethod.GETOBJECT)) {
       // query opensearch through getObject method
-      let getObjectPromise = openSearchWorkTransformer()(request.getobject, context);
+      let getObjectPromise = openSearchWorkTransformer(request.getobject, context);
       promises.push(getObjectPromise);
       services.push(requestMethod.GETOBJECT);
     }

--- a/src/provider/neoWorkTransformer.js
+++ b/src/provider/neoWorkTransformer.js
@@ -153,7 +153,7 @@ export function workFunc(context) {
     let promises = [];
     if (_.has(request, requestMethod.MOREINFO)) {
       // query moreinfo through its transformer.
-      let moreInfoPromise = coverImageTransformer()(request.moreinfo, context);
+      let moreInfoPromise = coverImageTransformer(request.moreinfo, context);
       promises.push(moreInfoPromise);
       services.push(requestMethod.MOREINFO);
     }


### PR DESCRIPTION
The transformers for coverImage and searchGetObject are also changed.
searchGetObject uses context.call, but coverImage needs the old baseSoapServer - but it is in the same structure as context.call.

The work transformer does not use context.call internally to call the other trasnformers. I'll need some help looking into that.