### PR TITLE
add basesoap functionality to context

### DIFF
--- a/src/provider/caller.js
+++ b/src/provider/caller.js
@@ -6,6 +6,7 @@
  */
 import request from 'request';
 import {sendRequest} from '../services/HTTPClient.js';
+import * as BaseSoapClient from 'dbc-node-basesoap-client';
 import fs from 'fs';
 
 // Flag that allows createTest endpoint parameter
@@ -66,6 +67,11 @@ function saveTest(test) {
   fs.writeFile(`${__dirname}/__tests__/autotest_${test.name}_${Date.now()}.js`, source);
 }
 
+class Context {
+  constructor(transformerMap, contextData) {
+    this.data = contextData;
+    this.transformerMap = transformerMap;
+  }
 /**
  * This is a method on the context object,
  * which allows calling other transformers, and external endpoints.
@@ -74,7 +80,7 @@ function saveTest(test) {
  * @param name the name of the endpoint
  * @param params the parameters to pass to the endpoint
  */
-function call(name, params) {
+call(name, params) {
   let promise, outerCall, startTime;
 
   let mockId = JSON.stringify([name, params]); // key for mock data
@@ -149,14 +155,11 @@ function call(name, params) {
     return result;
   });
 }
+}
 
 /**
  * Add a call function to the context.
  */
 export default function caller(transformerMap, contextData) {
-  let context = {};
-  context.data = contextData;
-  context.transformerMap = transformerMap;
-  context.call = call;
-  return context;
+  return new Context(transformerMap, contextData);
 }

--- a/src/provider/caller.js
+++ b/src/provider/caller.js
@@ -72,89 +72,89 @@ class Context {
     this.data = contextData;
     this.transformerMap = transformerMap;
   }
-/**
- * This is a method on the context object,
- * which allows calling other transformers, and external endpoints.
- *
- * @param this the context
- * @param name the name of the endpoint
- * @param params the parameters to pass to the endpoint
- */
-call(name, params) {
-  let promise, outerCall, startTime;
+  /**
+   * This is a method on the context object,
+   * which allows calling other transformers, and external endpoints.
+   *
+   * @param this the context
+   * @param name the name of the endpoint
+   * @param params the parameters to pass to the endpoint
+   */
+  call(name, params) {
+    let promise, outerCall, startTime;
 
-  let mockId = JSON.stringify([name, params]); // key for mock data
-  this.mockData = this.mockData || Object.assign({}, this.data.mockData || {}); // used for recording/playing mock data
-  let isRestCall = !this.transformerMap[name] && this.data[name] && this.data[name].url;
-  if (!this.requestId) {
-    this.requestId = randomId(); // identifier for request, useful for grepping etc.
-    outerCall = true;
-    this.createTest = params.createTest;
-    this.timings = params.timings;
-    this.externalCallsInProgress = 0;
-    this.externalTiming = 0;
-    startTime = Date.now();
-  }
+    let mockId = JSON.stringify([name, params]); // key for mock data
+    this.mockData = this.mockData || Object.assign({}, this.data.mockData || {}); // used for recording/playing mock data
+    let isRestCall = !this.transformerMap[name] && this.data[name] && this.data[name].url;
+    if (!this.requestId) {
+      this.requestId = randomId(); // identifier for request, useful for grepping etc.
+      outerCall = true;
+      this.createTest = params.createTest;
+      this.timings = params.timings;
+      this.externalCallsInProgress = 0;
+      this.externalTiming = 0;
+      startTime = Date.now();
+    }
 
-  if (this.transformerMap[name]) { // do call the actual transformer
-    promise = this.transformerMap[name](params, this);
+    if (this.transformerMap[name]) { // do call the actual transformer
+      promise = this.transformerMap[name](params, this);
 
-  }
-  else if (isRestCall) { // make a request to an external service
-    if (this.timings) {
-      if (this.externalCallsInProgress === 0) {
-        this.externalTiming -= Date.now();
+    }
+    else if (isRestCall) { // make a request to an external service
+      if (this.timings) {
+        if (this.externalCallsInProgress === 0) {
+          this.externalTiming -= Date.now();
+        }
+        ++this.externalCallsInProgress;
       }
-      ++this.externalCallsInProgress;
-    }
-    let url = this.data[name].url;
-    if (this.mockData && this.mockData[mockId]) {
-      promise = new Promise(resolve => resolve(this.mockData[mockId]));
-    }
-    else if (typeof params === 'string') {
-      promise = new Promise((resolve, reject) =>
-          request.post(url, {form: {xml: params}},
-            (err, _, data) => err ? reject(err) : resolve(data)));
-    }
-    else if (typeof params === 'object') {
-      promise = sendRequest(url, params);
-    }
-    else { // should never happen, can only occur if call is called with wrong parameters
-      throw 'call error: wrong parameters to endpoint';
-    }
-  }
-  else { // should never happen, - the endpoint does not exist (or has no endpoint-url defined in config)
-    throw 'call error: no such endpoint';
-  }
-
-  return promise.then(result => {
-    if (this.timings && isRestCall) {
-      --this.externalCallsInProgress;
-      if (this.externalCallsInProgress === 0) {
-        this.externalTiming += Date.now();
+      let url = this.data[name].url;
+      if (this.mockData && this.mockData[mockId]) {
+        promise = new Promise(resolve => resolve(this.mockData[mockId]));
+      }
+      else if (typeof params === 'string') {
+        promise = new Promise((resolve, reject) =>
+            request.post(url, {form: {xml: params}},
+              (err, _, data) => err ? reject(err) : resolve(data)));
+      }
+      else if (typeof params === 'object') {
+        promise = sendRequest(url, params);
+      }
+      else { // should never happen, can only occur if call is called with wrong parameters
+        throw 'call error: wrong parameters to endpoint';
       }
     }
-    if (testDev && this.createTest) { // save mock-data / create text-code
-      if (isRestCall) {
-        this.mockData[mockId] = result;
-      }
-      if (outerCall) {
-        delete params.createTest;
-        saveTest({name: name, params: params,
-          context: this.data,
-          mockData: this.mockData, result: result,
-          requestId: this.requestId});
-      }
+    else { // should never happen, - the endpoint does not exist (or has no endpoint-url defined in config)
+      throw 'call error: no such endpoint';
     }
-    if (outerCall && params.timings) {
-      result.timings = {
-        total: Date.now() - startTime,
-        external: this.externalTiming
-      };
-    }
-    return result;
-  });
-}
+
+    return promise.then(result => {
+      if (this.timings && isRestCall) {
+        --this.externalCallsInProgress;
+        if (this.externalCallsInProgress === 0) {
+          this.externalTiming += Date.now();
+        }
+      }
+      if (testDev && this.createTest) { // save mock-data / create text-code
+        if (isRestCall) {
+          this.mockData[mockId] = result;
+        }
+        if (outerCall) {
+          delete params.createTest;
+          saveTest({name: name, params: params,
+            context: this.data,
+            mockData: this.mockData, result: result,
+            requestId: this.requestId});
+        }
+      }
+      if (outerCall && params.timings) {
+        result.timings = {
+          total: Date.now() - startTime,
+          external: this.externalTiming
+        };
+      }
+      return result;
+    });
+  }
 }
 
 /**

--- a/src/provider/neoCoverImageTransform.js
+++ b/src/provider/neoCoverImageTransform.js
@@ -20,8 +20,6 @@
 import _ from 'lodash';
 import {log} from '../utils.js';
 
-import * as BaseSoapClient from 'dbc-node-basesoap-client';
-
 /**
  * Splits a PID into: type, agencyid and localid.
  * This functionality is needed as long as moreinfo
@@ -252,16 +250,19 @@ export default (request, context) => {
 
   let {transformedRequest: params, state: state} = moreInfoRequest(request, context);
 
-  let defaults = {
-    authentication: {
-      authenticationUser: context.data.moreinfo.user,
-      authenticationGroup: context.data.moreinfo.group,
-      authenticationPassword: context.data.moreinfo.password
+  let req = {
+    action: 'moreInfo',
+    params: params,
+    config: {
+      authentication: {
+        authenticationUser: context.data.moreinfo.user,
+        authenticationGroup: context.data.moreinfo.group,
+        authenticationPassword: context.data.moreinfo.password
+      }
     }
   };
-  let client = BaseSoapClient.client(context.data.moreinfo.url + '/moreinfo.wsdl', defaults, '');
 
-  return client.request('moreInfo', params, null, true).then(body => {
+  return context.basesoap('moreinfo', req).then(body => {
     return moreInfoResponse(body, context, state);
   });
 };


### PR DESCRIPTION
fixes #209 

&dash; also refactoring of context:

- context is now a proper es6 class
- urls can be passed directly, in addition to automatically being looked up in the context data.
- while call still dispatches automatically to transformer or rest/soap, there is now added methods to do the dispatch manually.