### PR TITLE
Empty pids in work

### DIFF
--- a/src/transformers/__tests__/work-empty_pidlist.js
+++ b/src/transformers/__tests__/work-empty_pidlist.js
@@ -1,0 +1,73 @@
+/* eslint-disable max-len, quotes, comma-spacing, key-spacing, quote-props, indent */
+// Request: work {"pids":[],"fields":["title","dcTitle","coverUrlFull","collection"]}
+'use strict';
+import Provider from '../../provider/Provider.js';
+import {assert, fail} from 'chai';
+
+let context = {
+  "services": {
+    "ddbcmsapi": "http://rest.filmstriben.dbc.inlead.dk/web/",
+    "moreinfo": "http://moreinfo.addi.dk/2.6/",
+    "openagency": "http://openagency.addi.dk/2.24/",
+    "openholdingstatus": "https://openholdingstatus.addi.dk/2.2/",
+    "openorder": "https://openorder.addi.dk/2.7.1/",
+    "TESTopenorder": "https://openorder.addi.dk/test_2.7.1/",
+    "opensearch": "http://opensearch.addi.dk/b3.0_4.2/",
+    "openuserstatus": "https://openuserstatus.addi.dk/1.4.1/",
+    "rank": "https://xptest.dbc.dk/ms/rank/v1",
+    "suggestpopular": "http://xptest.dbc.dk/ms/entity-pop/v1",
+    "suggestcreator": "http://xptest.dbc.dk/ms/entity-suggest/v1/creator",
+    "suggestlibrary": "http://xptest.dbc.dk/ms/entity-suggest/v1/library",
+    "suggestsubject": "http://xptest.dbc.dk/ms/entity-suggest/v1/subject",
+    "recommendurls": {
+      "default": "https://xptest.dbc.dk/ms/recommend-cosim/v1",
+      "popular": "https://xptest.dbc.dk/ms/recommend-pop/v1"
+    }
+  },
+  "search": {
+    "agency": "775100",
+    "profile": "opac",
+    "collectionidentifiers": "rec.collectionIdentifier:150013-palle OR rec.collectionIdentifier:758000-katalog"
+  },
+  "netpunkt": {
+    "user": "XXXXX",
+    "group": "XXXXX",
+    "password": "XXXXX"
+  },
+  "user": {
+    "agency": "775100",
+    "librarytype": "folkebibliotek",
+    "id": "XXXXX",
+    "pin": "XXXXX",
+    "salt": "XXXXX"
+  },
+  "app": {
+    "clientid": "XXXXX",
+    "ddbcmsapipassword": "XXXXX",
+    "orderpolicyrequester": "190101"
+  }
+};
+let provider = Provider();
+let mockData = {};
+
+describe('Automated test: work-empty_pidlist', () => {
+  it('expected response. ID:tpyptw, for {"pids":[],"fields":["title","dcTitle","coverUrlFull","collection"]}', (done) => {
+    context.mockData = mockData;
+    provider.execute('work', {"pids":[],"fields":["title","dcTitle","coverUrlFull","collection"]}, context)
+      .then(result => {
+        assert.deepEqual(result,
+            {
+  "statusCode": 400,
+  "error": "'pids' not present in request"
+});
+        done();
+      })
+      .catch(result => {
+        fail({throw: result}, {
+  "statusCode": 400,
+  "error": "'pids' not present in request"
+});
+        done();
+      });
+  });
+});

--- a/src/transformers/__tests__/work-no_pid_property.js
+++ b/src/transformers/__tests__/work-no_pid_property.js
@@ -1,0 +1,73 @@
+/* eslint-disable max-len, quotes, comma-spacing, key-spacing, quote-props, indent */
+// Request: work {"fields":["title","dcTitle","coverUrlFull","collection"]}
+'use strict';
+import Provider from '../../provider/Provider.js';
+import {assert, fail} from 'chai';
+
+let context = {
+  "services": {
+    "ddbcmsapi": "http://rest.filmstriben.dbc.inlead.dk/web/",
+    "moreinfo": "http://moreinfo.addi.dk/2.6/",
+    "openagency": "http://openagency.addi.dk/2.24/",
+    "openholdingstatus": "https://openholdingstatus.addi.dk/2.2/",
+    "openorder": "https://openorder.addi.dk/2.7.1/",
+    "TESTopenorder": "https://openorder.addi.dk/test_2.7.1/",
+    "opensearch": "http://opensearch.addi.dk/b3.0_4.2/",
+    "openuserstatus": "https://openuserstatus.addi.dk/1.4.1/",
+    "rank": "https://xptest.dbc.dk/ms/rank/v1",
+    "suggestpopular": "http://xptest.dbc.dk/ms/entity-pop/v1",
+    "suggestcreator": "http://xptest.dbc.dk/ms/entity-suggest/v1/creator",
+    "suggestlibrary": "http://xptest.dbc.dk/ms/entity-suggest/v1/library",
+    "suggestsubject": "http://xptest.dbc.dk/ms/entity-suggest/v1/subject",
+    "recommendurls": {
+      "default": "https://xptest.dbc.dk/ms/recommend-cosim/v1",
+      "popular": "https://xptest.dbc.dk/ms/recommend-pop/v1"
+    }
+  },
+  "search": {
+    "agency": "775100",
+    "profile": "opac",
+    "collectionidentifiers": "rec.collectionIdentifier:150013-palle OR rec.collectionIdentifier:758000-katalog"
+  },
+  "netpunkt": {
+    "user": "XXXXX",
+    "group": "XXXXX",
+    "password": "XXXXX"
+  },
+  "user": {
+    "agency": "775100",
+    "librarytype": "folkebibliotek",
+    "id": "XXXXX",
+    "pin": "XXXXX",
+    "salt": "XXXXX"
+  },
+  "app": {
+    "clientid": "XXXXX",
+    "ddbcmsapipassword": "XXXXX",
+    "orderpolicyrequester": "190101"
+  }
+};
+let provider = Provider();
+let mockData = {};
+
+describe('Automated test: work-no_pid_property', () => {
+  it('expected response. ID:m7i5a6, for {"fields":["title","dcTitle","coverUrlFull","collection"]}', (done) => {
+    context.mockData = mockData;
+    provider.execute('work', {"fields":["title","dcTitle","coverUrlFull","collection"]}, context)
+      .then(result => {
+        assert.deepEqual(result,
+            {
+  "statusCode": 400,
+  "error": "'pids' not present in request"
+});
+        done();
+      })
+      .catch(result => {
+        fail({throw: result}, {
+  "statusCode": 400,
+  "error": "'pids' not present in request"
+});
+        done();
+      });
+  });
+});

--- a/src/transformers/work.js
+++ b/src/transformers/work.js
@@ -162,6 +162,14 @@ export function workResponse(response, context, state) { // eslint-disable-line 
 }
 
 export default (request, context) => {
+  let error;
+  if (!request.pids || request.pids.length === 0) {
+    error = {statusCode: 400, error: '\'pids\' not present in request'};
+  }
+  if (error) {
+    return Promise.resolve(error);
+  }
+
   let {transformedRequest: params, state: state} = workRequest(request, context);
 
   let services = []; // state-data for knowing which servies is called and in which order.


### PR DESCRIPTION
Fixed error: when empty pidslist or no request-property 'pids' an error was thrown. Now a sensible error-response is created.