### PR TITLE
Add prettier + pre-commit hook for prettying

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -109,7 +109,6 @@
     // XP "no-unused-vars": 2,
     "no-use-before-define": 2,
     // Stylistic Issues
-    "indent": [2, 2, {"SwitchCase": 1}],
     // XP
     // "brace-style": [
     //   2,
@@ -156,18 +155,6 @@
       "always"
     ],
     "padded-blocks": 0,
-    "quotes": [
-      2,
-      "single"
-    ],
-    "quote-props": [
-      2,
-      "as-needed"
-    ],
-    "semi": [
-      2,
-      "always"
-    ],
     "sort-vars": [
       0,
       {
@@ -186,12 +173,11 @@
     "wrap-regex": 0,
     // Legacy
     "max-depth": 0,
-    "max-len": [
-      2,
-      180
-    ],
     "max-params": 0,
     "max-statements": 0,
     "no-plusplus": 0
-  }
+  },
+  "extends": [
+    "prettier"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The ServiceProvider or DBC Open Platform is the API for the danish public libraries.\n\nThe ServiceProvider provides access to DBCs services. The purpose is to make a unified, easy-to-use way to access the different bibliographic APIs. The serviceprovider works as a gateway to other services, and does not include the actual search/database/etc. logic.",
   "main": "src/main.js",
   "scripts": {
+    "prettier": "prettier --no-bracket-spacing --single-quote --write src/*.js src/*/*.js src/*/*/*.js src/*/*/*/*.js",
     "complexity": "cr -c .complexrc ./src",
     "preinstall": "cp -n context-sample.json context.json || true",
     "apitest": "cd qa/apitest; ./apitest.sh",
@@ -25,6 +26,7 @@
     "before:commit": "npm run lint && npm run coverage && npm run cukes:cover && npm run collect:coverage && npm run sonar",
     "sonar": "sonar-runner -Dsonar.projectKey=sp:local -Dsonar.projectName=ServiceProviderLocal -Dsonar.projectVersion=1.0 -Dsonar.sources=./src"
   },
+  "DISABLED UNTIL WE HAVE RUN PRETTIER ON EXISTING CODE pre-commit": ["prettier"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/DBCDK/serviceprovider.git"
@@ -73,13 +75,16 @@
     "cucumber": "^2.1.0",
     "cucumberjs-junitxml": "1.0.0",
     "eslint": "^3.0.1",
+    "eslint-config-prettier": "^2.8.0",
     "eslint-loader": "^1.0.0",
-    "istanbul-instrumenter-loader": "^3.0.0",
     "istanbul": "^0.4.4",
     "istanbul-combine": "^0.3.0",
+    "istanbul-instrumenter-loader": "^3.0.0",
     "mocha": "^3.1.0",
     "nock": "^9.0.2",
     "npm-run-all": "^4.0.2",
+    "pre-commit": "^1.2.2",
+    "prettier": "^1.8.2",
     "sinon": "^2.2.0",
     "socketcluster-client": "^5.0.13",
     "superagent": "^3.5.2",

--- a/src/transformers/moreinfo.js
+++ b/src/transformers/moreinfo.js
@@ -106,16 +106,16 @@ function containsError(response) {
     const status = miResponse.requestStatus;
     if (status.statusEnum.$ === 'ok') {
       return false;
-    } else { // eslint-disable-line no-else-return
-      if (_.has(status, 'errorText.$')) {
-        log.error('Error in response: ErrorCode: '
-          + status.statusEnum.$ + ' ErrorText: '
-          + status.errorText.$);
-      } else {
-        log.error('Error in response: ErrorCode: ' + status.statusEnum.$);
-      }
-      return true;
     }
+
+    if (_.has(status, 'errorText.$')) {
+      log.error('Error in response: ErrorCode: '
+        + status.statusEnum.$ + ' ErrorText: '
+        + status.errorText.$);
+    } else {
+      log.error('Error in response: ErrorCode: ' + status.statusEnum.$);
+    }
+    return true;
   }
 
   log.error('No statusEnum in response!');


### PR DESCRIPTION
Just changed the commit to just have the configuration for prettier etc., such that we can merge it immediately. ~~Don't merge this until all other pull requests / branches has been merged or rebased. Otherwise they will get conflicts, and it is easier just to fix the conflict in this one.~~ 

Use prettier for indenting, this especially makes the autogenerated unit tests easier to work with. Fixes #816.

The formatting parameters to `prettier` was determined by what was most similar to existing code (smallest diff after formatting).

Eslinting is preserved in order to catch non-formatting issues, but some formatting rules removed that conflicted with prettier's formatting.