### PR TITLE
Wait for child processes

### DIFF
--- a/start-service-provider.sh
+++ b/start-service-provider.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 PORT=3000 node src/smaug/minismaug.js -f context-sample.json & sleep 2
-SMAUG=http://localhost:3000 MOCK_FILE=apitest/mockdata.json SWAGGER_HTTP=true TEST_DEV=true node src/main.js & sleep 10
+SMAUG=http://localhost:3000 MOCK_FILE=apitest/mockdata.json SWAGGER_HTTP=true TEST_DEV=true node src/main.js
 
+wait


### PR DESCRIPTION
Hi!

I've been playing around with serviceprovider / open platform as part of a contract with Napp A/S.

Setup was very smooth, however the start script surprised me, in that I had to manually find the pids of the processes started and kill, whenever I wished to stop / restart the server.

I don't know if this is something that fits with the way this script was meant to be used, but the readme indicates so. Otherwise I'm fine with you closing this PR