### PR TITLE
Log params som string i stedet for objekt.

### DIFF
--- a/src/provider/caller.js
+++ b/src/provider/caller.js
@@ -161,7 +161,7 @@ class Context {
     if (this.externalCallsInProgress === 0 && type === 'transformer') {
       log.info('transformer-done', {
         name,
-        params,
+        paramsStr: JSON.stringify(params),
         timings: {
           total: Date.now() - this.startTime,
           external: this.externalTiming


### PR DESCRIPTION
del af #957

Skulle løse ihvertfald en af konflikterne ved logning.
(Er nysgerrig om det er denne konflikt, der gør at log ikke samles op)

