### PR TITLE
1003 materialvurderinger after review slf

### DIFF
--- a/src/transformers/opensearchGetObject.js
+++ b/src/transformers/opensearchGetObject.js
@@ -369,7 +369,7 @@ function getFullTextReviewsData(searchResult) {
       reviews.push(singleReview);
     }
   });
-  return reviews.length === 0 ? {}: {fullTextReviews: reviews};
+  return reviews.length === 0 ? {} : {fullTextReviews: reviews};
 }
 
 /**

--- a/src/transformers/opensearchGetObject.js
+++ b/src/transformers/opensearchGetObject.js
@@ -365,9 +365,11 @@ function getFullTextReviewsData(searchResult) {
         singleReview.push(review);
       }
     });
-    reviews.push(singleReview);
+    if (singleReview.length !== 0) {
+      reviews.push(singleReview);
+    }
   });
-  return {fullTextReviews: reviews};
+  return reviews.length === 0 ? {}: {fullTextReviews: reviews};
 }
 
 /**


### PR DESCRIPTION
Efter Kaspers test kommentar: Hvis der ikke findes en (eller flere) lektørudtalelse(r) på et materiale, skal der slet ikke forekomme et fullTextReviews felt i resultatet.