### PR TITLE
add created column. include _created in when retrieving objects

### DIFF
--- a/src/transformers/__tests__/storage.test.js
+++ b/src/transformers/__tests__/storage.test.js
@@ -483,7 +483,7 @@ describe('Storage endpoint', () => {
         _version: doc2._version,
         _id: doc2._id,
         _client: 'CLIENT_ID',
-        _created: doc2._created
+        _created: result._created
       });
     });
 

--- a/src/transformers/__tests__/storage.test.js
+++ b/src/transformers/__tests__/storage.test.js
@@ -139,7 +139,8 @@ describe('Storage endpoint', () => {
         _type: 'bf130fb7-8bd4-44fd-ad1d-43b6020ad102',
         _id: 'bf130fb7-8bd4-44fd-ad1d-43b6020ad102',
         _version: String(typeDocument._version),
-        _client: 'openplatform'
+        _client: 'openplatform',
+        _created: String(typeDocument._created)
       });
     });
   });
@@ -207,7 +208,8 @@ describe('Storage endpoint', () => {
         _type: type1._id,
         _id: doc1._id,
         _version: String(result._version),
-        _client: 'CLIENT_ID'
+        _client: 'CLIENT_ID',
+        _created: String(result._created)
       });
     });
 
@@ -322,8 +324,10 @@ describe('Storage endpoint', () => {
         _type: type1._id,
         _id: doc1._id,
         _version: String(result._version),
-        _client: 'CLIENT_ID'
+        _client: 'CLIENT_ID',
+        _created: String(result._created)
       });
+      assert.notEqual(String(result._version), String(result._created));
     });
 
     it('throws a conflict if we try to change a document with the wrong version', async () => {
@@ -401,7 +405,8 @@ describe('Storage endpoint', () => {
         _type: type1._id,
         _id: doc1._id,
         _version: String(result._version),
-        _client: 'CLIENT_ID'
+        _client: 'CLIENT_ID',
+        _created: String(result._created)
       });
     });
   });
@@ -477,7 +482,8 @@ describe('Storage endpoint', () => {
         _owner: user,
         _version: doc2._version,
         _id: doc2._id,
-        _client: 'CLIENT_ID'
+        _client: 'CLIENT_ID',
+        _created: doc2._created
       });
     });
 
@@ -793,7 +799,8 @@ describe('Storage endpoint', () => {
           _version: result._version,
           key: 'a',
           public: true,
-          title: 'hello world - public'
+          title: 'hello world - public',
+          _created: String(result._created)
         },
         result
       );
@@ -832,7 +839,8 @@ describe('Storage endpoint', () => {
           _version: result._version,
           key: 'a',
           public: false,
-          title: 'hello world - private'
+          title: 'hello world - private',
+          _created: String(result._created)
         },
         result
       );

--- a/src/transformers/aggregations/__tests__/list.test.js
+++ b/src/transformers/aggregations/__tests__/list.test.js
@@ -30,29 +30,29 @@ describe('List observer', () => {
         type: 'json',
         permissions: {read: 'if object.public'},
         indexes: [
-          {value: '_id', keys: ['cf_type', 'cf_key', 'cf_created']},
-          {value: '_id', keys: ['cf_type', 'cf_created']},
+          {value: '_id', keys: ['cf_type', 'cf_key', '_created']},
+          {value: '_id', keys: ['cf_type', '_created']},
           {
             value: '_id',
-            keys: ['_owner', 'cf_type', 'cf_key', 'cf_created'],
+            keys: ['_owner', 'cf_type', 'cf_key', '_created'],
             private: true
           },
           {
             value: '_id',
-            keys: ['_owner', 'cf_type', 'cf_key', 'cf_created']
+            keys: ['_owner', 'cf_type', 'cf_key', '_created']
           },
           {
             value: '_id',
-            keys: ['_owner', 'cf_type', 'cf_created'],
+            keys: ['_owner', 'cf_type', '_created'],
             private: true
           },
           {
             value: '_id',
-            keys: ['_owner', 'cf_type', 'cf_created']
+            keys: ['_owner', 'cf_type', '_created']
           },
           {
             value: '_id',
-            keys: ['cf_type', 'cf_key', 'cf_created'],
+            keys: ['cf_type', 'cf_key', '_created'],
             admin: true
           }
         ]

--- a/src/transformers/aggregations/list.observer.js
+++ b/src/transformers/aggregations/list.observer.js
@@ -28,14 +28,14 @@ function isType(obj) {
 }
 function isValidType(obj) {
   const requiredIndexes = [
-    {value: '_id', keys: ['cf_type', 'cf_key', 'cf_created']},
+    {value: '_id', keys: ['cf_type', 'cf_key', '_created']},
     {
       value: '_id',
-      keys: ['_owner', 'cf_type', 'cf_created']
+      keys: ['_owner', 'cf_type', '_created']
     },
     {
       value: '_id',
-      keys: ['cf_type', 'cf_key', 'cf_created'],
+      keys: ['cf_type', 'cf_key', '_created'],
       admin: true
     }
   ];
@@ -55,7 +55,7 @@ async function onUpdate(prev, obj, type, storage) {
       const lists = (await storage.scan(
         {
           _type: obj._id,
-          index: ['cf_type', 'cf_key', 'cf_created'],
+          index: ['cf_type', 'cf_key', '_created'],
           startsWith: ['list']
         },
         null,
@@ -169,7 +169,7 @@ async function refreshList(listId, type, storage) {
     const owner = (await storage.scan(
       {
         _type: list._type,
-        index: ['_owner', 'cf_type', 'cf_created'],
+        index: ['_owner', 'cf_type', '_created'],
         startsWith: [list._owner, 'USER_PROFILE'],
         expand: true
       },
@@ -180,7 +180,7 @@ async function refreshList(listId, type, storage) {
     const items = (await storage.scan(
       {
         _type: list._type,
-        index: ['cf_type', 'cf_key', 'cf_created'],
+        index: ['cf_type', 'cf_key', '_created'],
         startsWith: ['list-entry', list._id],
         expand: true
       },
@@ -190,7 +190,7 @@ async function refreshList(listId, type, storage) {
     let num_comments = (await storage.scan(
       {
         _type: list._type,
-        index: ['cf_type', 'cf_key', 'cf_created'],
+        index: ['cf_type', 'cf_key', '_created'],
         startsWith: ['comment', list._id]
       },
       null,
@@ -200,7 +200,7 @@ async function refreshList(listId, type, storage) {
       const numItemComments = (await storage.scan(
         {
           _type: list._type,
-          index: ['cf_type', 'cf_key', 'cf_created'],
+          index: ['cf_type', 'cf_key', '_created'],
           startsWith: ['comment', items[i]._id]
         },
         null,
@@ -211,7 +211,7 @@ async function refreshList(listId, type, storage) {
     let num_follows = (await storage.scan(
       {
         _type: list._type,
-        index: ['cf_type', 'cf_key', 'cf_created'],
+        index: ['cf_type', 'cf_key', '_created'],
         startsWith: ['follows', list._id]
       },
       null,
@@ -230,8 +230,8 @@ async function refreshList(listId, type, storage) {
       num_items: items.length,
       num_comments,
       num_follows,
-      created: new Date(list.cf_created * 1000),
-      modified: new Date(list.cf_modified * 1000),
+      created: list._created,
+      modified: list._version,
       pids: JSON.stringify(items.map(item => item.pid))
     };
 

--- a/src/transformers/storage.js
+++ b/src/transformers/storage.js
@@ -40,7 +40,8 @@ function parseJsonDoc(result) {
     _type: result.type,
     _id: result.id,
     _version: result.version,
-    _client: result.client
+    _client: result.client,
+    _created: result.created
   });
 }
 
@@ -67,6 +68,7 @@ async function get({_id}, user, context) {
 
   result = result[0];
   result.version = new Date(result.version).toISOString();
+  result.created = new Date(result.created).toISOString();
   switch (type.type) {
     case 'json':
       const data = parseJsonDoc(result);
@@ -94,7 +96,8 @@ async function get({_id}, user, context) {
           _type: result.type,
           _id: result.id,
           _version: result.version,
-          _client: result.client
+          _client: result.client,
+          _created: result._created
         }
       };
     default:
@@ -579,7 +582,8 @@ async function scan(
         'docs.client',
         'docs.owner',
         'docs.type',
-        'docs.data'
+        'docs.data',
+        'docs.created'
       )
       .where({'idIndex.type': _type, idx})
       .innerJoin('docs', 'val', 'docs.id');
@@ -895,6 +899,14 @@ async function initDB() {
       table.string('userId').notNullable();
       table.uuid('roleId').notNullable();
       table.primary(['userId', 'roleId']);
+    });
+  }
+  if (!(await knex.schema.hasColumn('docs', 'created'))) {
+    await knex.schema.table('docs', table => {
+      table
+        .timestamp('created')
+        .notNullable()
+        .defaultTo(knex.fn.now());
     });
   }
 }

--- a/src/transformers/storage.js
+++ b/src/transformers/storage.js
@@ -97,7 +97,7 @@ async function get({_id}, user, context) {
           _id: result.id,
           _version: result.version,
           _client: result.client,
-          _created: result._created
+          _created: result.created
         }
       };
     default:

--- a/tools/migrate_created_timestamps.js
+++ b/tools/migrate_created_timestamps.js
@@ -1,0 +1,18 @@
+const {traverseAll, knex} = require('./storage-traverser');
+
+traverseAll(async doc => {
+  const oldCreated = doc._created
+    ? new Date(Math.floor(doc._created.getTime() / 1000) * 1000).toISOString()
+    : new Date().toISOString();
+
+  const newCreated = doc.cf_created
+    ? new Date(doc.cf_created * 1000).toISOString()
+    : new Date(Math.floor(doc._version.getTime() / 1000) * 1000).toISOString();
+  if (oldCreated !== newCreated) {
+    // should update
+    console.log(doc._id, newCreated, oldCreated);
+    await knex('docs')
+      .where({id: doc._id})
+      .update({created: newCreated});
+  }
+});

--- a/tools/storage-traverser.js
+++ b/tools/storage-traverser.js
@@ -4,13 +4,10 @@ const config = {
 };
 const knex = require('knex')(config);
 
-// will traverse in streaming fashion
-// ie. should not run out of memory
-traverseAll(async doc => {
-  // DO STUFF TO EACH DOC HERE
-  console.log(doc._id);
-});
-
+/**
+ * Will traverse in streaming fashion
+ * ie. should not run out of memory
+ */
 async function traverseAll(callback) {
   let remaining;
   let counter = 0;
@@ -60,3 +57,5 @@ function parseImg(result) {
     _created: result.created
   };
 }
+
+module.exports = {traverseAll, knex};

--- a/tools/storage-traverser.js
+++ b/tools/storage-traverser.js
@@ -1,0 +1,62 @@
+const config = {
+  client: 'pg',
+  connection: process.env.PG_CONNECTION_STRING
+};
+const knex = require('knex')(config);
+
+// will traverse in streaming fashion
+// ie. should not run out of memory
+traverseAll(async doc => {
+  // DO STUFF TO EACH DOC HERE
+  console.log(doc._id);
+});
+
+async function traverseAll(callback) {
+  let remaining;
+  let counter = 0;
+  await knex
+    .select('*')
+    .from('docs')
+    .stream(stream => {
+      stream.on('data', async data => {
+        stream.pause();
+        counter++;
+        const parsed = parse(data);
+        remaining = callback(parsed);
+        await remaining;
+        stream.resume();
+      });
+    });
+  await remaining;
+  console.log('Traversal completed', counter);
+}
+
+function parse(result) {
+  try {
+    return parseJsonDoc(result);
+  } catch (e) {
+    return parseImg(result);
+  }
+}
+function parseJsonDoc(result) {
+  return Object.assign({}, JSON.parse(result.data.toString('utf-8')), {
+    _owner: result.owner,
+    _type: result.type,
+    _id: result.id,
+    _version: result.version,
+    _client: result.client,
+    _created: result.created
+  });
+}
+
+function parseImg(result) {
+  return {
+    _data: result.data.toString('latin1'),
+    _owner: result.owner,
+    _type: result.type,
+    _id: result.id,
+    _version: result.version,
+    _client: result.client,
+    _created: result.created
+  };
+}

--- a/tools/traverse_example.js
+++ b/tools/traverse_example.js
@@ -1,0 +1,6 @@
+const {traverseAll} = require('./storage-traverser');
+
+traverseAll(async doc => {
+  // DO STUFF TO EACH DOC HERE
+  console.log(doc._id);
+});


### PR DESCRIPTION
Når denne er merget ind vil alle dokumenter have sat created til migreringstidspunktet.
Derfor skal der manuelt køres noget sql-voodoo der:
 - kopierer version-kolonnen (modified) over i created. Det er det bedste vi kan gøre for ikke-content-first-objekter
 - for dokumenter der har en cf_created skal cf_created lægges over i created-kolonnen...